### PR TITLE
Update parties.js to include the new group that separated from PVV

### DIFF
--- a/src/parties.js
+++ b/src/parties.js
@@ -2,8 +2,14 @@ const parties = [
   {
     name: "PVV",
     eerste: 4,
-    seats: 26,
+    seats: 19,
     color: "#2e89b5",
+  },
+  {
+    name: "Groep Markuszower",
+    eerste: 0,
+    seats: 7,
+    color: "#0e6995",
   },
   {
     name: "D66",


### PR DESCRIPTION
The so-dubbed [Groep Markuszower](https://nl.wikipedia.org/wiki/Groep_Markuszower) split off from the PVV, taking 7 seats with them.